### PR TITLE
Updated spatial resolution for wildfire on quickstart guide

### DIFF
--- a/docs/explorer.html
+++ b/docs/explorer.html
@@ -237,10 +237,10 @@ higher cadence reporting, please contact us for custom requests.</p>
     </tr>
     <tr>
       <td>Wildfire Burned Area Fraction</td>
-      <td>Annual fraction of land exposed to wildfire within 14km radius of the asset</td>
+      <td>Annual fraction of land exposed to wildfire within 6.9km radius of the asset</td>
       <td>Fraction</td>
       <td>0.0 to 1.0</td>
-      <td>14km</td>
+      <td>6.9km</td>
       <td>LOW: 0.0 to 0.000081; MEDIUM: 0.00008 to 0.01; HIGH: &gt; 0.01</td>
       <td>1.0</td>
     </tr>

--- a/jekyll/explorer.md
+++ b/jekyll/explorer.md
@@ -85,7 +85,7 @@ For creating standard heatmaps, we assess the physical risk over the 30 year win
 | Annual Temperature | Annual mean annual temperature at the asset location | °C | -5 to 45 | 100km | N/A | N/A |
 | Annual Precipitation | Annual total precipitation at the asset location | mm | 0 to 5000 | 100km | N/A | N/A |
 | Extreme Precipitation | Annual probabilistic projections of number of days in a year where precipitation exceeds 51mm | Number of days | 0 to 365 | 100km | N/A | N/A |
-| Wildfire Burned Area Fraction | Annual fraction of land exposed to wildfire within 14km radius of the asset | Fraction | 0.0 to 1.0 | 14km | LOW: 0.0 to 0.000081; MEDIUM: 0.00008 to 0.01; HIGH: > 0.01 | 1.0 |
+| Wildfire Burned Area Fraction | Annual fraction of land exposed to wildfire within 6.9km radius of the asset | Fraction | 0.0 to 1.0 | 6.9km | LOW: 0.0 to 0.000081; MEDIUM: 0.00008 to 0.01; HIGH: > 0.01 | 1.0 |
 | Wildfire Susceptibility | Average annual probability of a wildfire occurring across all land areas within 1km of the asset | Probability Score | 0.0 to 1.0 | 300m | LOW: 0.0 to 0.05; MEDIUM: 0.05 to 0.075; HIGH: 0.075 to 1.0 | 1.0 |
 | Inland Flooding | Annual exposure of asset to floods | Probability score | 0.0 to 1.0 | 4km | Based on number of years with probability of flood >5%; LOW: 0; MEDIUM: 1 to 2; HIGH >2 | 1.0 |
 | Heatwaves | Annual heatwave days per year where temperature at asset is projected to exceed 98th percentile of historic recordings | Number of days | 0 to 365 | 100km | LOW: 0 to 30; MEDIUM: 30 to 50; HIGH: >50 | 200 |


### PR DESCRIPTION
*Updated spatial resolution for the burned area fraction indicator to 6.9km, not 14km as documented
